### PR TITLE
adding schemaDownload to vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "json.schemaDownload.enable": true,
     "python.formatting.provider": "black",
     "python.testing.pytestEnabled": true,
     "python.linting.enabled": true,


### PR DESCRIPTION
adding "json.schemaDownload.enable": true to vsc settings to resolve vsc schema error.